### PR TITLE
Make apps-script-sample vitest-compatible

### DIFF
--- a/packages/apps-script-sample/package.json
+++ b/packages/apps-script-sample/package.json
@@ -10,7 +10,7 @@
   ],
   "type": "module",
   "scripts": {
-    "build": "rollup --config --no-treeshake && cp appsscript.json dist/",
+    "build": "rm -rf dist && rollup --config --no-treeshake && cp appsscript.json dist/",
     "build:check": "yarn check && yarn build",
     "build:redeploy": "yarn build:check && yarn redeploy",
     "redeploy": "./clasp-redeploy.sh",
@@ -21,7 +21,8 @@
     "format": "prettier '{src,tests}/**/*.{js,ts}' --write",
     "check": "yarn typecheck && yarn lint && yarn format:check",
     "fix": "yarn lint:fix && yarn format",
-    "test": "echo 'Placeholder in case we ever add tests'",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "ci": "yarn check && yarn test"
   },
   "devDependencies": {
@@ -33,6 +34,7 @@
     "rollup": "^4.61.1",
     "tslib": "^2.8.1",
     "typescript": "^6.0.2",
-    "typescript-eslint": "^8.57.2"
+    "typescript-eslint": "^8.57.2",
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/apps-script-sample/rollup.config.js
+++ b/packages/apps-script-sample/rollup.config.js
@@ -2,15 +2,15 @@ import { nodeResolve } from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
 
 export default {
-  input: "src/app.ts",
+  input: "src/main.ts",
   output: {
-    dir: "dist",
-    format: "cjs",
+    file: "dist/app.js",
+    format: "esm",
   },
   plugins: [
     nodeResolve({
       extensions: [".ts", ".js"],
     }),
-    typescript(),
+    typescript({ tsconfig: "./tsconfig.build.json" }),
   ],
 };

--- a/packages/apps-script-sample/src/app.ts
+++ b/packages/apps-script-sample/src/app.ts
@@ -1,4 +1,4 @@
-//! Make changes in https://github.com/righteffort/empower-poster/packages/apps-script-sample/src/
+// Make changes in https://github.com/righteffort/empower-poster/packages/apps-script-sample/src/
 
 import type {
   PostPayload,
@@ -73,8 +73,7 @@ function writeAccounts(
   }
 }
 
-// @ts-expect-error: Used from Apps Script
-function doPost(e: GoogleAppsScript.Events.DoPost) {
+export function doPost(e: GoogleAppsScript.Events.DoPost) {
   try {
     const {
       version: { major, minor },
@@ -131,4 +130,9 @@ function doPost(e: GoogleAppsScript.Events.DoPost) {
       JSON.stringify(responseBody),
     ).setMimeType(ContentService.MimeType.JSON);
   }
+}
+
+// Placeholder to demonstrate unit testing.
+export function placeholder(): boolean {
+  return true;
 }

--- a/packages/apps-script-sample/src/main.ts
+++ b/packages/apps-script-sample/src/main.ts
@@ -1,0 +1,1 @@
+import "./app.js";

--- a/packages/apps-script-sample/tests/app.test.ts
+++ b/packages/apps-script-sample/tests/app.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest";
+
+import { placeholder } from "../src/app.js";
+
+describe("placeholder", () => {
+  it("should do nothing", () => {
+    expect(placeholder()).toStrictEqual(true);
+  });
+});

--- a/packages/apps-script-sample/tsconfig.build.json
+++ b/packages/apps-script-sample/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/apps-script-sample/tsconfig.json
+++ b/packages/apps-script-sample/tsconfig.json
@@ -21,10 +21,10 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
-    "rootDir": "./src",
-    "outDir": "./dist"
+    "noEmit": true
   },
   "include": [
     "src/**/*.ts",
+    "tests/**/*.ts",
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,6 +963,7 @@ __metadata:
     tslib: "npm:^2.8.1"
     typescript: "npm:^6.0.2"
     typescript-eslint: "npm:^8.57.2"
+    vitest: "npm:^4.1.8"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Integrated Vitest testing framework, replacing placeholder test setup with automated test execution.

* **Chores**
  * Updated build system to output ES modules instead of CommonJS.
  * Added dedicated build configuration for improved build process organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->