### PR TITLE
Correct CI failures in last commit

### DIFF
--- a/packages/extension/src/processing.ts
+++ b/packages/extension/src/processing.ts
@@ -83,7 +83,7 @@ export function getHoldingsAndAccounts(holdingsIn: HoldingEntryIn[]): {
         quantity: h.quantity,
         value: h.value,
         ticker: cleanTicker(h.ticker || "") || h.description || "",
-        fundFees: h.fundFees ?? null
+        fundFees: h.fundFees ?? null,
       });
     }
     if (userAccountId != null && accountName) {

--- a/packages/extension/testdata/getHoldings-expected.json
+++ b/packages/extension/testdata/getHoldings-expected.json
@@ -2,6 +2,7 @@
   "holdings": [
     {
       "cusip": "ca",
+      "fundFees": 0.00025,
       "userAccountId": 1,
       "ticker": "Cash",
       "price": 1,
@@ -10,6 +11,7 @@
     },
     {
       "cusip": "bn",
+      "fundFees": 0.0003,
       "userAccountId": 2,
       "ticker": "BND",
       "price": 5,
@@ -18,6 +20,7 @@
     },
     {
       "cusip": "ca",
+      "fundFees": 0.00035,
       "userAccountId": 2,
       "ticker": "Cash",
       "price": 1,
@@ -26,6 +29,7 @@
     },
     {
       "cusip": "vt",
+      "fundFees": 0.0004,
       "userAccountId": 3,
       "ticker": "VTI",
       "price": 0.20,
@@ -34,6 +38,7 @@
     },
     {
       "cusip": "bn",
+      "fundFees": 0.00045,
       "userAccountId": 3,
       "ticker": "BND",
       "price": 4.1,
@@ -42,6 +47,7 @@
     },
     {
       "cusip": "ss",
+      "fundFees": 0,
       "userAccountId": 4,
       "ticker": "FSPSX",
       "price": 0.42,
@@ -50,6 +56,7 @@
     },
     {
       "cusip": "",
+      "fundFees": null,
       "userAccountId": 4,
       "ticker": "Oddball",
       "price": 1.67,
@@ -58,6 +65,7 @@
     },
     {
       "cusip": "",
+      "fundFees": null,
       "userAccountId": 4,
       "ticker": "ZEROV",
       "price": 0,

--- a/packages/extension/testdata/getHoldings-input.json
+++ b/packages/extension/testdata/getHoldings-input.json
@@ -1,6 +1,7 @@
 [
   {
     "cusip": "ca",
+    "fundFees": 0.00025,
     "description": "Cash",
     "accountName": "One",
     "userAccountId": 1,
@@ -10,6 +11,7 @@
   },
   {
     "cusip": "bn",
+    "fundFees": 0.0003,
     "description": "Bonds",
     "accountName": "Two",
     "userAccountId": 2,
@@ -20,6 +22,7 @@
   },
   {
     "cusip": "ca",
+    "fundFees": 0.00035,
     "description": "Cash",
     "accountName": "Two",
     "userAccountId": 2,
@@ -29,6 +32,7 @@
   },
   {
     "cusip": "vt",
+    "fundFees": 0.0004,
     "description": "Stocks",
     "price": 0.20,
     "quantity": 495.05,
@@ -39,6 +43,7 @@
   },
   {
     "cusip": "bn",
+    "fundFees": 0.00045,
     "description": "Bonds",
     "price": 4.1,
     "quantity": 3.8,
@@ -49,6 +54,7 @@
   },
   {
     "cusip": "ss",
+    "fundFees": 0,
     "description": "Stocks",
     "price": 0.42,
     "quantity": 3,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Holdings now include fee information for each position, improving the detail shown in holdings data.
* **Bug Fixes**
  * Updated holdings output to match the latest expected structure, including fee values where available and `null` for entries without a CUSIP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->